### PR TITLE
Use underscore to check the type of the keypath

### DIFF
--- a/lib/underscore-keypath.js
+++ b/lib/underscore-keypath.js
@@ -56,10 +56,10 @@
 
 	function toSegments(keypath) {
 		"use strict";
-		if (typeof keypath === "object" && keypath.constructor.name === "Array") {
+		if (underscore.isArray(keyPath)) {
 			return Array.prototype.slice.call(keypath);
 		}
-		if (typeof keypath === "string") {
+		if (underscore.isString(keyPath)) {
 			keypath = keypath.replace(/\.\./g, "«dot»");
 
 			// issue #1 https://github.com/jeeeyul/underscore-keypath/issues/1


### PR DESCRIPTION
`function toSegments(keypath)`
Move to underscore functions to check the keypath type.